### PR TITLE
Make the title optional on the ForgotPasswordForm

### DIFF
--- a/lib/src/widgets/forgot_password_form.dart
+++ b/lib/src/widgets/forgot_password_form.dart
@@ -7,15 +7,15 @@ class ForgotPasswordForm extends StatefulWidget {
   const ForgotPasswordForm({
     super.key,
     required this.options,
-    required this.title,
     required this.description,
     required this.onRequestForgotPassword,
+    this.title,
     this.initialEmail,
   });
 
   final LoginOptions options;
 
-  final Widget title;
+  final Widget? title;
   final Widget description;
   final String? initialEmail;
 


### PR DESCRIPTION
A title is not always required. For example sometimes you'd want to put the title in an appbar outside the form instead. This makes that possible.