### PR TITLE
feat: get title and subtitle from the widget itself and don't provide defaults for them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.0.0
+
+* Removed `title` and `subtitle` parameters from `LoginOptions` in favour of passing them directly to the `EmailPasswordLoginForm` widget directly
+
 ## 6.1.0
 
 * Added 'suffixIconSize' and 'suffixIconPadding' to LoginOptions.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -12,7 +12,6 @@ final loginOptions = LoginOptions(
     prefixIcon: Icon(Icons.password),
     border: OutlineInputBorder(),
   ),
-  title: const Text('Login Demo'),
   image: const FlutterLogo(
     size: 200,
   ),
@@ -56,6 +55,7 @@ class LoginScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       body: EmailPasswordLoginForm(
+        title: const Text('Login Demo'),
         options: loginOptions,
         onLogin: (email, password) => print('$email:$password'),
         onRegister: (email, password, ctx) => print('Register!'),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -68,7 +68,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "6.0.0"
+    version: "6.1.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -83,26 +83,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -131,10 +131,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   path:
     dependency: transitive
     description:
@@ -208,10 +208,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   universal_platform:
     dependency: transitive
     description:
@@ -232,10 +232,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.1"
 sdks:
-  dart: ">=3.2.0-0 <4.0.0"
-  flutter: ">=3.7.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/src/config/login_options.dart
+++ b/lib/src/config/login_options.dart
@@ -10,15 +10,6 @@ import 'package:flutter_login/src/service/validation.dart';
 class LoginOptions {
   const LoginOptions({
     this.image,
-    this.title = const Text(
-      'Log in',
-      style: TextStyle(
-        color: Color(0xff71C6D1),
-        fontWeight: FontWeight.w800,
-        fontSize: 24,
-      ),
-    ),
-    this.subtitle,
     this.maxFormWidth,
     this.emailTextStyle,
     this.passwordTextStyle,
@@ -105,12 +96,6 @@ class LoginOptions {
 
   /// The image to display on the login screen.
   final Widget? image;
-
-  /// The title widget to display on the login screen.
-  final Widget? title;
-
-  /// The subtitle widget to display on the login screen.
-  final Widget? subtitle;
 
   /// Option to modify the spacing between the title, subtitle, image, form,
   /// and button.

--- a/lib/src/widgets/email_password_login.dart
+++ b/lib/src/widgets/email_password_login.dart
@@ -6,6 +6,8 @@ import 'package:flutter_login/flutter_login.dart';
 class EmailPasswordLoginForm extends StatefulWidget {
   /// Constructs an [EmailPasswordLoginForm] widget.
   ///
+  /// [title]: The title to display above the form.
+  /// [subtitle]: A subtitle to display below the title.
   /// [onLogin]: Callback function for user login.
   /// [onForgotPassword]: Callback function for when the user
   /// forgets their password.
@@ -13,13 +15,19 @@ class EmailPasswordLoginForm extends StatefulWidget {
   /// [options]: The options for configuring the login form.
   const EmailPasswordLoginForm({
     required this.onLogin,
-    super.key,
+    this.title,
+    this.subtitle,
     this.onForgotPassword,
     this.onRegister,
     this.options = const LoginOptions(),
+    super.key,
   });
 
   final LoginOptions options;
+
+  final Widget? title;
+  final Widget? subtitle;
+
   final void Function(String email, BuildContext ctx)? onForgotPassword;
   final FutureOr<void> Function(
     String email,
@@ -101,11 +109,11 @@ class _EmailPasswordLoginFormState extends State<EmailPasswordLoginForm> {
                       if (options.spacers.spacerBeforeTitle != null) ...[
                         Spacer(flex: options.spacers.spacerBeforeTitle!),
                       ],
-                      if (options.title != null) ...[
+                      if (widget.title != null) ...[
                         Align(
                           alignment: Alignment.topCenter,
                           child: wrapWithDefaultStyle(
-                            options.title,
+                            widget.title,
                             theme.textTheme.headlineSmall,
                           ),
                         ),
@@ -113,11 +121,11 @@ class _EmailPasswordLoginFormState extends State<EmailPasswordLoginForm> {
                       if (options.spacers.spacerAfterTitle != null) ...[
                         Spacer(flex: options.spacers.spacerAfterTitle!),
                       ],
-                      if (options.subtitle != null) ...[
+                      if (widget.subtitle != null) ...[
                         Align(
                           alignment: Alignment.topCenter,
                           child: wrapWithDefaultStyle(
-                            options.subtitle,
+                            widget.subtitle,
                             theme.textTheme.titleSmall,
                           ),
                         ),

--- a/lib/src/widgets/forgot_password_form.dart
+++ b/lib/src/widgets/forgot_password_form.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_login/flutter_login.dart';
 
-// ignore: must_be_immutable
 class ForgotPasswordForm extends StatefulWidget {
   /// Constructs a [ForgotPasswordForm] widget.
   ///
@@ -12,44 +11,18 @@ class ForgotPasswordForm extends StatefulWidget {
   /// password reset.
   /// [title]: Widget to display title.
   /// [description]: Widget to display description.
-  ForgotPasswordForm({
+  const ForgotPasswordForm({
     required this.options,
     required this.onRequestForgotPassword,
     this.title,
     this.description,
     super.key,
-  }) {
-    title == null
-        ? title = const Padding(
-            padding: EdgeInsets.only(bottom: 8.0),
-            child: Text(
-              'Forgot Password',
-              style: TextStyle(
-                color: Color(0xff71C6D1),
-                fontWeight: FontWeight.w800,
-                fontSize: 24,
-              ),
-            ),
-          )
-        : title = title;
-
-    description == null
-        ? description = const Padding(
-            padding: EdgeInsets.only(bottom: 16),
-            child: Text(
-              'No worries. Enter your email address below so we can'
-              ' send you a link to reset your password.',
-              textAlign: TextAlign.center,
-              style: TextStyle(fontWeight: FontWeight.w400, fontSize: 16),
-            ),
-          )
-        : description = description;
-  }
+  });
 
   final LoginOptions options;
 
-  Widget? title;
-  Widget? description;
+  final Widget? title;
+  final Widget? description;
 
   final FutureOr<void> Function(String email) onRequestForgotPassword;
 

--- a/lib/src/widgets/forgot_password_form.dart
+++ b/lib/src/widgets/forgot_password_form.dart
@@ -8,16 +8,16 @@ class ForgotPasswordForm extends StatefulWidget {
   /// Constructs a [ForgotPasswordForm] widget.
   ///
   /// [options]: The options for configuring the forgot password form.
-  /// [description]: Widget to display description.
   /// [onRequestForgotPassword]: Callback function for requesting
   /// password reset.
   /// [title]: Widget to display title.
+  /// [description]: Widget to display description.
   ForgotPasswordForm({
     required this.options,
     required this.onRequestForgotPassword,
+    this.title,
     this.description,
     super.key,
-    this.title,
   }) {
     title == null
         ? title = const Padding(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_login
 description: Flutter Login Component
-version: 6.1.0
+version: 7.0.0
 
 environment:
   sdk: ">=2.18.1 <3.0.0"


### PR DESCRIPTION
Sometimes the consumer doesn't want a title, subtitle or description. However it wasn't possible to leave them empty before these changes.